### PR TITLE
README: set correct line number for local development

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ yarn storybook # Start Storybook
                # See Keycloakify's storybook for if you need a starting point for your stories: https://github.com/keycloakify/keycloakify/tree/main/stories
 
 yarn start # See the Hello World app
-           # Uncomment line 15 of src/keycloak-theme/login/kcContext, reload https://localhost:3000
+           # Uncomment line 97 of src/keycloak-theme/login/kcContext where it reads: `mockPageId: "login.ftl"`, reload https://localhost:3000
            # You can now develop your Login pages. (Don't forget to comment it back when you're done)
 
 yarn build-keycloak-theme # Actually build the theme


### PR DESCRIPTION
In "Quick start" section the line number for uncommenting to enable local development is wrong. Set the correct number and add the content of the line for easier discovery by the developers.