### PR TITLE
Update .gitignore - yarn cache dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,16 @@ jspm_packages
 # Optional npm cache directory
 .npm
 
+# yarn cache directory
+.pnp.*
+.yarn/*
+!.yarn/patches
+!.yarn/plugins
+!.yarn/releases
+!.yarn/sdks
+!.yarn/versions
+
+
 # Optional REPL history
 .node_repl_history
 


### PR DESCRIPTION
Yarn produce many files when running yarn install. According to their doc[1], most of the files should be ignored, unless a zero-install strategy is wanted (which is not the case here AFAIK).

[1] https://yarnpkg.com/getting-started/qa#which-files-should-be-gitignored