### PR TITLE
Add devcontainer support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,23 @@
+{
+  "name": "Keycloakify Starter Devcontainer",
+  "image": "mcr.microsoft.com/devcontainers/typescript-node:1-20-bookworm",
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "moby": true,
+      "installDockerBuildx": true,
+      "version": "latest",
+      "dockerDashComposeVersion": "none"
+    },
+    "ghcr.io/devcontainers-contrib/features/maven-sdkman:2": {
+      "version": "latest",
+      "jdkVersion": "latest",
+      "jdkDistro": "ms"
+    }
+  },
+  "postCreateCommand": "yarn install",
+  "customizations": {
+    "vscode": {
+      "extensions": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ npx download-builtin-keycloak-theme # For downloading the default theme (as a re
                                     # Look for the files in dist_keycloak/src/main/resources/theme/{base,keycloak}
 ```
 
+## Using a development container
+
+This starter supports [development containers](https://containers.dev/). You can customize the configuatuation file [`.devcontainer.json`](./.devcontainer/devcontainer.json) to your liking.
+
 # Theme variant  
 
 Keycloakify enables you to create different variant for a single theme.  


### PR DESCRIPTION
I have been using a devcontainer with this starter and I think using it makes the whole process much easier.  A simple container config pretty much supports all the functionalities of this repo. As a bonus, people won't need to install node or java environments just to modify their login pages.