### PR TITLE
Add `/.rendered` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,6 @@ jspm_packages
 /dist_keycloak
 /build
 /storybook-static
+
+# build output of `jsx-email`
+/.rendered


### PR DESCRIPTION
Fixes #57

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated ignored files to exclude build output from the `jsx-email` tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->